### PR TITLE
#58 update account setting

### DIFF
--- a/app/assets/javascripts/account.js
+++ b/app/assets/javascripts/account.js
@@ -1,16 +1,49 @@
-// 合計科目が損益科目の場合期首残高の数字を0、入力不可にする
+// 合計科目が損益科目の場合期首残高の数字を0、読取専用にする
 $(document).on('turbolinks:load', function() {
+  const PROFIT_AND_LOSS_STATEMENT = ['収入', '原価', '販管費', '営業外収入', '営業外費用'];
   // 合計科目を変更した場合
   $(document).on('change', '#account_total_account', function(){
-    let PROFIT_AND_LOSS_STATEMENT = ['収入', '原価', '販管費', '営業外収入', '営業外費用'];
     if(PROFIT_AND_LOSS_STATEMENT.includes($(this).val())){
       $(this).parent('td').prev().children('input').val(0);
-      $(this).parent('td').prev().children('input').prop('disabled', true);
+      $(this).parent('td').prev().children('input').prop('readonly', true);
       $(this).parent('div').prev().children('input').val(0);
-      $(this).parent('div').prev().children('input').prop('disabled', true);
+      $(this).parent('div').prev().children('input').prop('readonly', true);
     }else{
-      $(this).parent('td').prev().children('input').prop('disabled', false);
-      $(this).parent('div').prev().children('input').prop('disabled', false);
+      $(this).parent('td').prev().children('input').prop('readonly', false);
+      $(this).parent('div').prev().children('input').prop('readonly', false);
     }
   });
+
+  // create失敗時のrender(update失敗時はviewで対応)
+  const target = $('#account_total_account')
+  if(PROFIT_AND_LOSS_STATEMENT.includes($(target).val())){
+    $(target).parent('td').prev().children('input').val(0);
+    $(target).parent('td').prev().children('input').prop('readonly', true);
+  }
+});
+
+
+// Enterキーでタブ移動出来るようにする
+$(document).on('turbolinks:load', function() {
+
+  const target = ['#account_name', '#account_code', '#account_opening_balance_1', '#account_total_account'];
+  target.forEach(function(target){
+    $(document).on('keydown', target, function(){
+      enter_change_tab();
+    });
+  });
+
+  // function集
+  function enter_change_tab(){
+    const elements = 'input[type=text]';
+    $(elements).keypress(function(e){
+      const c = e.which ? e.which : e.keyCode;
+      if(c == 13){
+        let index = $(this).attr('tabindex');
+        index = String(Number(index) + 1);
+        $('[tabindex=' + index + ']').focus();
+        e.preventDefault(); //Enter送信無効
+      }
+    });
+  }
 });

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -28,8 +28,9 @@ class AccountsController < ApplicationController
   def update
     @account = Account.find(params[:id])
     prev_balance = @account.opening_balance_1.to_i
-    @account.update(account_params)
-    @account.update_opening_balance(prev_balance)
+    if @account.update(account_params)
+     @account.update_opening_balance(prev_balance)
+    end
   end
 
   def destroy

--- a/app/views/accounts/_edit.html.erb
+++ b/app/views/accounts/_edit.html.erb
@@ -1,15 +1,15 @@
 <%= form_with model: account, url: account_path, class:'account__edit-form-group', remote: true do |f| %>
-  <div class='account__edit-td--code'><%= f.text_field :code, class:'account__edit-form--code' %></div>
-  <div class='account__edit-td--name'><%= f.text_field :name, class:'account__edit-form--name' %></div>
+  <div class='account__edit-td--code'><%= f.text_field :code, tabindex: 1, class:'account__edit-form--code' %></div>
+  <div class='account__edit-td--name'><%= f.text_field :name, tabindex: 2, class:'account__edit-form--name' %></div>
   <% if Account::PROFIT_AND_LOSS_STATEMENT.include?(account.total_account) %>
-    <div class='account__edit-td--balance'><%= f.text_field :opening_balance_1, disabled: true, class:'account__edit-form--balance' %></div>
+    <div class='account__edit-td--balance'><%= f.text_field :opening_balance_1, readonly: true, tabindex: 3, class:'account__edit-form--balance' %></div>
   <% else %>
-    <div class='account__edit-td--balance'><%= f.text_field :opening_balance_1, class:'account__edit-form--balance' %></div>
+    <div class='account__edit-td--balance'><%= f.text_field :opening_balance_1, tabindex: 3, class:'account__edit-form--balance' %></div>
   <% end %>
   <div class='account__edit-td--total'>
     <%= f.select :total_account, [['現預金'], ['他流動資産'], ['固定資産'],
               ['カード'], ['他流動負債'],['固定負債'], ['収入'], ['原価'],
-              ['販管費'], ['営業外収入'],['営業外費用']], {include_blank: '合計科目'}, class:'account__edit-form--total' %>
+              ['販管費'], ['営業外収入'],['営業外費用']], {include_blank: '合計科目'}, { tabindex: 4, class:'account__edit-form--total' } %>
   </div>
   <div class='account__edit-td--btn'>
     <%= f.button type: 'submit', class:'account__edit-btn' do %>

--- a/app/views/accounts/_new.html.erb
+++ b/app/views/accounts/_new.html.erb
@@ -19,18 +19,18 @@
     <tbody class='account__add-tbody'>
       <tr class='account__add-tr'>
         <td class='account__add-td'>
-          <%= f.text_field :code, class:'account__add-text-field' %>
+          <%= f.text_field :code, tabindex: 11, class:'account__add-text-field' %>
         </td>
         <td class='account__add-td'>
-          <%= f.text_field :name, class:'account__add-text-field' %>
+          <%= f.text_field :name, tabindex: 12, class:'account__add-text-field' %>
         </td>
         <td class='account__add-td'>
-          <%= f.text_field :opening_balance_1, class:'account__add-text-field' %>
+          <%= f.text_field :opening_balance_1, tabindex: 13, class:'account__add-text-field' %>
         </td>
         <td class='account__add-td'>
           <%= f.select :total_account, [['現預金'], ['他流動資産'], ['固定資産'],
               ['カード'], ['他流動負債'],['固定負債'], ['収入'], ['原価'],
-              ['販管費'], ['営業外収入'],['営業外費用']], {include_blank: '選択してください'}, class:'account__add-select' %>
+              ['販管費'], ['営業外収入'],['営業外費用']], {include_blank: '選択してください'}, { tabindex: 14, class:'account__add-select' } %>
         </td>
         <td class='account__add-td--btn'>
           <%= f.submit '追加', class:'account__add-btn' %>


### PR DESCRIPTION
- 勘定科目設定画面にてEnter押下時の挙動を送信から横移動に変更
- #59 にて対応した損益科目の場合、期首残高を0以外に設定できなくする挙動について漏れがあったので、修正
- 損益科目の場合、期首残高のフォームをdisabledで対応したいと考えていたが、難しかったのでreadonly属性での対応に変更