### PR TITLE
refactoring

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,7 @@ class ApplicationController < ActionController::Base
     @get_start_month = 0
     @get_end_month = 0
 
-    (1..12).to_a.each do |m|
+    (1..12).each do |m|
       get_month = params["mon#{m}".to_sym].to_i
       if @get_start_month == 0 && get_month == 1
         @get_start_month = m

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -103,7 +103,7 @@ class Account < ApplicationRecord
     end
 
     # monthより後の期首残高を更新
-    ("#{month + 1}".to_i..12).to_a.each do |mon|
+    ("#{month + 1}".to_i..12).each do |mon|
       update_opening_balance = send("opening_balance_#{mon}")
       update_opening_balance += update_balance
       hash["opening_balance_#{mon}"] = update_opening_balance
@@ -115,7 +115,7 @@ class Account < ApplicationRecord
   def update_opening_balance(prev_balance)
     update_balance = opening_balance_1 - prev_balance
     hash = {}
-    (2..12).to_a.each do |mon|
+    (2..12).each do |mon|
       update_opening_balance = send("opening_balance_#{mon}")
       update_opening_balance += update_balance
       hash["opening_balance_#{mon}"] = update_opening_balance
@@ -128,7 +128,7 @@ class Account < ApplicationRecord
     debit_balance = 0
     credit_balance = 0
     opening_balance = send("opening_balance_#{start_month}")
-    (start_month..end_month).to_a.each do |mon|
+    (start_month..end_month).each do |mon|
       debit_balance += send("debit_balance_#{mon}")
       credit_balance += send("credit_balance_#{mon}")
     end
@@ -144,7 +144,7 @@ class Account < ApplicationRecord
   def return_transition_balances(end_month)
     array = []
     # 1月から終了月
-    (1..end_month).to_a.each do |mon|
+    (1..end_month).each do |mon|
       if DEBIT_ACCOUNTS.include?(total_account)
         array.push(send("debit_balance_#{mon}") - send("credit_balance_#{mon}"))
       else
@@ -152,7 +152,7 @@ class Account < ApplicationRecord
       end
     end
     # 終了月から12月
-    ((end_month + 1)..12).to_a.each do |mon|
+    ((end_month + 1)..12).each do |mon|
       array.push(0)
     end
     # 累計残高
@@ -165,7 +165,7 @@ class Account < ApplicationRecord
   def balance_array_from_1_to_12
     array = []
     # 1月から11月の期末残高（2月から12月の期首残高）
-    (2..12).to_a.each do |mon|
+    (2..12).each do |mon|
       array.push(send("opening_balance_#{mon}"))
     end
     # 12月の期末残高

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -241,7 +241,7 @@ class User < ApplicationRecord
     accounts.each do |account|
       if Account::PROFIT_AND_LOSS_STATEMENT.include?(account.total_account)
         array = []
-        (1..12).to_a.each do |mon|
+        (1..12).each do |mon|
           array.push(account.send("credit_balance_#{mon}") - account.send("debit_balance_#{mon}"))
         end
         profit_array = [profit_array, array].transpose.map { |n| n.inject(:+) }

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe '勘定科目モデルに関するテスト', type: :model do
         @other_account = create(:account, user: user, code: 101, total_account: 'カード')
         hash = {}
         other_hash = {}
-        (1..12).to_a.each do |mon|
+        (1..12).each do |mon|
           hash["debit_balance_#{mon}"] = 1000
           hash["credit_balance_#{mon}"] = 2000
           hash["opening_balance_#{mon}"] = 10000
@@ -150,13 +150,13 @@ RSpec.describe '勘定科目モデルに関するテスト', type: :model do
           expect(@other_account.opening_balance_1).to eq 20000
           expect(@other_account.opening_balance_2).to eq 20000
           expect(@other_account.debit_balance_1).to eq 3000
-          (3..12).to_a.each do |mon|
+          (3..12).each do |mon|
             expect(@account.send("debit_balance_#{mon}")).to eq 1000
             expect(@other_account.send("debit_balance_#{mon}")).to eq 3000
           end
         end
         it '貸方残高は変わっていない' do
-          (1..12).to_a.each do |mon|
+          (1..12).each do |mon|
             expect(@account.send("credit_balance_#{mon}")).to eq 2000
             expect(@other_account.send("credit_balance_#{mon}")).to eq 4000
           end
@@ -166,7 +166,7 @@ RSpec.describe '勘定科目モデルに関するテスト', type: :model do
           expect(@other_account.debit_balance_2).to eq 3500
         end
         it '指定月より後の期首残高が変わっている' do
-          (3..12).to_a.each do |mon|
+          (3..12).each do |mon|
             expect(@account.send("opening_balance_#{mon}")).to eq 10500
             expect(@other_account.send("opening_balance_#{mon}")).to eq 19500
           end
@@ -185,13 +185,13 @@ RSpec.describe '勘定科目モデルに関するテスト', type: :model do
           expect(@other_account.opening_balance_1).to eq 20000
           expect(@other_account.opening_balance_2).to eq 20000
           expect(@other_account.credit_balance_1).to eq 4000
-          (3..12).to_a.each do |mon|
+          (3..12).each do |mon|
             expect(@account.send("credit_balance_#{mon}")).to eq 2000
             expect(@other_account.send("credit_balance_#{mon}")).to eq 4000
           end
         end
         it '借方残高は変わっていない' do
-          (1..12).to_a.each do |mon|
+          (1..12).each do |mon|
             expect(@account.send("debit_balance_#{mon}")).to eq 1000
             expect(@other_account.send("debit_balance_#{mon}")).to eq 3000
           end
@@ -201,7 +201,7 @@ RSpec.describe '勘定科目モデルに関するテスト', type: :model do
           expect(@other_account.credit_balance_2).to eq 4500
         end
         it '指定月より後の期首残高が変わっている' do
-          (3..12).to_a.each do |mon|
+          (3..12).each do |mon|
             expect(@account.send("opening_balance_#{mon}")).to eq 9500
             expect(@other_account.send("opening_balance_#{mon}")).to eq 20500
           end
@@ -214,7 +214,7 @@ RSpec.describe '勘定科目モデルに関するテスト', type: :model do
         user = create(:user, year: 2021)
         account = create(:account, user: user)
         hash = {}
-        (1..12).to_a.each do |mon|
+        (1..12).each do |mon|
           hash["opening_balance_#{mon}"] = mon*100
         end
         account.update(hash)
@@ -222,7 +222,7 @@ RSpec.describe '勘定科目モデルに関するテスト', type: :model do
         account.update(opening_balance_1: 101)
         account.update_opening_balance(prev_balance)
 
-        (2..12).to_a.each do |mon|
+        (2..12).each do |mon|
           expect(account.send("opening_balance_#{mon}")).to eq (mon * 100 + 1)
         end
       end
@@ -235,7 +235,7 @@ RSpec.describe '勘定科目モデルに関するテスト', type: :model do
         other_account = create(:account, user: user, code: 101, total_account: 'カード')
         hash = {}
         other_hash = {}
-        (1..12).to_a.each do |mon|
+        (1..12).each do |mon|
           hash["opening_balance_#{mon}"] = 50 * (mon * mon - mon + 2)
           hash["debit_balance_#{mon}"] = mon * 200
           hash["credit_balance_#{mon}"] = mon * 100
@@ -258,7 +258,7 @@ RSpec.describe '勘定科目モデルに関するテスト', type: :model do
         other_account = create(:account, user: user, code: 101, total_account: 'カード')
         hash = {}
         other_hash = {}
-        (1..12).to_a.each do |mon|
+        (1..12).each do |mon|
           hash["opening_balance_#{mon}"] = 50 * (mon * mon - mon + 2)
           hash["debit_balance_#{mon}"] = mon * 200
           hash["credit_balance_#{mon}"] = mon * 100
@@ -281,7 +281,7 @@ RSpec.describe '勘定科目モデルに関するテスト', type: :model do
         other_account = create(:account, user: user, code: 101, total_account: 'カード')
         hash = {}
         other_hash = {}
-        (1..12).to_a.each do |mon|
+        (1..12).each do |mon|
           hash["opening_balance_#{mon}"] = 50 * (mon * mon - mon + 2)
           hash["debit_balance_#{mon}"] = mon * 200
           hash["credit_balance_#{mon}"] = mon * 100

--- a/spec/models/import_spec.rb
+++ b/spec/models/import_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe '仕訳取込モデルに関するテスト', type: :model do
         other_account = create(:account, user: @user, code: 101, name: 'test')
         hash = {}
         other_hash = {}
-        (1..12).to_a.each do |mon|
+        (1..12).each do |mon|
           hash["debit_balance_#{mon}"] = 1000
           hash["credit_balance_#{mon}"] = 2000
           hash["opening_balance_#{mon}"] = 10000
@@ -198,12 +198,12 @@ RSpec.describe '仕訳取込モデルに関するテスト', type: :model do
           expect(Journal.all.length).to eq 1
         end
         it '借方科目の貸方残高は変わっていない' do
-        (1..12).to_a.each do |mon|
-          expect(@account.send("credit_balance_#{mon}")).to eq 2000
-        end
+          (1..12).each do |mon|
+            expect(@account.send("credit_balance_#{mon}")).to eq 2000
+          end
         end
         it '貸方科目の借方残高は変わっていない' do
-          (1..12).to_a.each do |mon|
+          (1..12).each do |mon|
             expect(@other_account.send("debit_balance_#{mon}")).to eq 3000
           end
         end
@@ -219,13 +219,13 @@ RSpec.describe '仕訳取込モデルに関するテスト', type: :model do
         end
         it '借方科目の仕訳作成月の借方残高、仕訳作成月より後の期首残高は変わっている' do
           expect(@account.debit_balance_2).to eq 1500
-          (3..12).to_a.each do |mon|
+          (3..12).each do |mon|
             expect(@account.send("opening_balance_#{mon}")).to eq 10500
           end
         end
         it '貸方科目の仕訳作成月の貸方残高、仕訳作成月より後の期首残高は変わっている' do
           expect(@other_account.credit_balance_2).to eq 4500
-          (3..12).to_a.each do |mon|
+          (3..12).each do |mon|
             expect(@other_account.send("opening_balance_#{mon}")).to eq 19500
           end
         end
@@ -246,7 +246,7 @@ RSpec.describe '仕訳取込モデルに関するテスト', type: :model do
           expect(Journal.all.length).to eq 0
         end
         it '勘定科目の残高が変わっていない' do
-          (1..12).to_a.each do |mon|
+          (1..12).each do |mon|
             expect(@account.send("debit_balance_#{mon}")).to eq 1000
             expect(@account.send("credit_balance_#{mon}")).to eq 2000
             expect(@account.send("opening_balance_#{mon}")).to eq 10000

--- a/spec/models/journal_spec.rb
+++ b/spec/models/journal_spec.rb
@@ -282,7 +282,7 @@ RSpec.describe '仕訳モデルに関するテスト', type: :model do
         other_account = create(:account, user: @user, code: 101, name: 'test')
         hash = {}
         other_hash = {}
-        (1..12).to_a.each do |mon|
+        (1..12).each do |mon|
           hash["debit_balance_#{mon}"] = 1000
           hash["credit_balance_#{mon}"] = 2000
           hash["opening_balance_#{mon}"] = 10000
@@ -304,7 +304,7 @@ RSpec.describe '仕訳モデルに関するテスト', type: :model do
           end
 
           it '借方コードの貸方残高、貸方コードの借方残高は更新されていない' do
-            (1..12).to_a.each do |mon|
+            (1..12).each do |mon|
               expect(@account.send("credit_balance_#{mon}")).to eq 2000
               expect(@other_account.send("debit_balance_#{mon}")).to eq 3000
             end
@@ -312,7 +312,7 @@ RSpec.describe '仕訳モデルに関するテスト', type: :model do
           it '借方コードの2月以外借方残高、貸方コードの2月以外貸方残高は更新されていない' do
             expect(@account.debit_balance_1).to eq 1000
             expect(@other_account.credit_balance_1).to eq 4000
-            (3..12).to_a.each do |mon|
+            (3..12).each do |mon|
               expect(@account.send("debit_balance_#{mon}")).to eq 1000
               expect(@other_account.send("credit_balance_#{mon}")).to eq 4000
             end
@@ -322,13 +322,13 @@ RSpec.describe '仕訳モデルに関するテスト', type: :model do
             expect(@other_account.credit_balance_2).to eq 4500
           end
           it '1,2月の期首残高は変わっていない' do
-            (1..2).to_a.each do |mon|
+            (1..2).each do |mon|
               expect(@account.send("opening_balance_#{mon}")).to eq 10000
               expect(@other_account.send("opening_balance_#{mon}")).to eq 20000
             end
           end
           it '3月以降の期首残高は正しく更新されている' do
-            (3..12).to_a.each do |mon|
+            (3..12).each do |mon|
               expect(@account.send("opening_balance_#{mon}")).to eq 10500
               expect(@other_account.send("opening_balance_#{mon}")).to eq 19500
             end
@@ -343,7 +343,7 @@ RSpec.describe '仕訳モデルに関するテスト', type: :model do
           end
 
           it '借方コードの貸方残高、貸方コードの借方残高は更新されていない' do
-            (1..12).to_a.each do |mon|
+            (1..12).each do |mon|
               expect(@account.send("credit_balance_#{mon}")).to eq 2000
               expect(@other_account.send("debit_balance_#{mon}")).to eq 3000
             end
@@ -351,7 +351,7 @@ RSpec.describe '仕訳モデルに関するテスト', type: :model do
           it '借方コードの2月以外借方残高、貸方コードの2月以外貸方残高は更新されていない' do
             expect(@account.debit_balance_1).to eq 1000
             expect(@other_account.credit_balance_1).to eq 4000
-            (3..12).to_a.each do |mon|
+            (3..12).each do |mon|
               expect(@account.send("debit_balance_#{mon}")).to eq 1000
               expect(@other_account.send("credit_balance_#{mon}")).to eq 4000
             end
@@ -361,13 +361,13 @@ RSpec.describe '仕訳モデルに関するテスト', type: :model do
             expect(@other_account.credit_balance_2).to eq 3500
           end
           it '1,2月の期首残高は変わっていない' do
-            (1..2).to_a.each do |mon|
+            (1..2).each do |mon|
               expect(@account.send("opening_balance_#{mon}")).to eq 10000
               expect(@other_account.send("opening_balance_#{mon}")).to eq 20000
             end
           end
           it '3月以降の期首残高は正しく更新されている' do
-            (3..12).to_a.each do |mon|
+            (3..12).each do |mon|
               expect(@account.send("opening_balance_#{mon}")).to eq 9500
               expect(@other_account.send("opening_balance_#{mon}")).to eq 20500
             end
@@ -383,7 +383,7 @@ RSpec.describe '仕訳モデルに関するテスト', type: :model do
         end
 
         it '全ての残高が変わっていない' do
-          (1..12).to_a.each do |mon|
+          (1..12).each do |mon|
             expect(@account.send("debit_balance_#{mon}")).to eq 1000
             expect(@account.send("credit_balance_#{mon}")).to eq 2000
             expect(@account.send("opening_balance_#{mon}")).to eq 10000
@@ -402,7 +402,7 @@ RSpec.describe '仕訳モデルに関するテスト', type: :model do
         other_account = create(:account, user: @user, code: 101, name: 'test')
         hash = {}
         other_hash = {}
-        (1..12).to_a.each do |mon|
+        (1..12).each do |mon|
           hash["debit_balance_#{mon}"] = 1000
           hash["credit_balance_#{mon}"] = 2000
           hash["opening_balance_#{mon}"] = 10000
@@ -427,12 +427,12 @@ RSpec.describe '仕訳モデルに関するテスト', type: :model do
           expect(Journal.all.length).to eq 1
         end
         it '借方科目の貸方残高は変わっていない' do
-        (1..12).to_a.each do |mon|
+        (1..12).each do |mon|
           expect(@account.send("credit_balance_#{mon}")).to eq 2000
         end
         end
         it '貸方科目の借方残高は変わっていない' do
-          (1..12).to_a.each do |mon|
+          (1..12).each do |mon|
             expect(@other_account.send("debit_balance_#{mon}")).to eq 3000
           end
         end
@@ -448,13 +448,13 @@ RSpec.describe '仕訳モデルに関するテスト', type: :model do
         end
         it '借方科目の仕訳作成月の借方残高、仕訳作成月より後の期首残高は変わっている' do
           expect(@account.debit_balance_2).to eq 1500
-          (3..12).to_a.each do |mon|
+          (3..12).each do |mon|
             expect(@account.send("opening_balance_#{mon}")).to eq 10500
           end
         end
         it '貸方科目の仕訳作成月の貸方残高、仕訳作成月より後の期首残高は変わっている' do
           expect(@other_account.credit_balance_2).to eq 4500
-          (3..12).to_a.each do |mon|
+          (3..12).each do |mon|
             expect(@other_account.send("opening_balance_#{mon}")).to eq 19500
           end
         end
@@ -472,7 +472,7 @@ RSpec.describe '仕訳モデルに関するテスト', type: :model do
           expect(Journal.all.length).to eq 0
         end
         it '勘定科目の残高が変わっていない' do
-          (1..12).to_a.each do |mon|
+          (1..12).each do |mon|
             expect(@account.send("debit_balance_#{mon}")).to eq 1000
             expect(@account.send("credit_balance_#{mon}")).to eq 2000
             expect(@account.send("opening_balance_#{mon}")).to eq 10000
@@ -491,7 +491,7 @@ RSpec.describe '仕訳モデルに関するテスト', type: :model do
         other_account = create(:account, user: @user, code: 101, name: 'test')
         hash = {}
         other_hash = {}
-        (1..12).to_a.each do |mon|
+        (1..12).each do |mon|
           hash["debit_balance_#{mon}"] = 1000
           hash["credit_balance_#{mon}"] = 2000
           hash["opening_balance_#{mon}"] = 10000
@@ -517,12 +517,12 @@ RSpec.describe '仕訳モデルに関するテスト', type: :model do
           expect(Journal.all.length).to eq 1
         end
         it '借方科目の貸方残高は変わっていない' do
-        (1..12).to_a.each do |mon|
+        (1..12).each do |mon|
           expect(@account.send("credit_balance_#{mon}")).to eq 2000
         end
         end
         it '貸方科目の借方残高は変わっていない' do
-          (1..12).to_a.each do |mon|
+          (1..12).each do |mon|
             expect(@other_account.send("debit_balance_#{mon}")).to eq 3000
           end
         end
@@ -538,13 +538,13 @@ RSpec.describe '仕訳モデルに関するテスト', type: :model do
         end
         it '借方科目の仕訳作成月の借方残高、仕訳作成月より後の期首残高は変わっている' do
           expect(@account.debit_balance_2).to eq 1500
-          (3..12).to_a.each do |mon|
+          (3..12).each do |mon|
             expect(@account.send("opening_balance_#{mon}")).to eq 10500
           end
         end
         it '貸方科目の仕訳作成月の貸方残高、仕訳作成月より後の期首残高は変わっている' do
           expect(@other_account.credit_balance_2).to eq 4500
-          (3..12).to_a.each do |mon|
+          (3..12).each do |mon|
             expect(@other_account.send("opening_balance_#{mon}")).to eq 19500
           end
         end
@@ -562,7 +562,7 @@ RSpec.describe '仕訳モデルに関するテスト', type: :model do
           expect(Journal.all.length).to eq 0
         end
         it '勘定科目の残高が変わっていない' do
-          (1..12).to_a.each do |mon|
+          (1..12).each do |mon|
             expect(@account.send("debit_balance_#{mon}")).to eq 1000
             expect(@account.send("credit_balance_#{mon}")).to eq 2000
             expect(@account.send("opening_balance_#{mon}")).to eq 10000
@@ -581,7 +581,7 @@ RSpec.describe '仕訳モデルに関するテスト', type: :model do
         other_account = create(:account, user: @user, code: 101, name: 'test')
         hash = {}
         other_hash = {}
-        (1..12).to_a.each do |mon|
+        (1..12).each do |mon|
           hash["debit_balance_#{mon}"] = 1000
           hash["credit_balance_#{mon}"] = 2000
           hash["opening_balance_#{mon}"] = 10000
@@ -607,7 +607,7 @@ RSpec.describe '仕訳モデルに関するテスト', type: :model do
         end
         it '以下の残高は変わっていない' do
           # 自身科目の貸方残高、相手科目の借方残高
-          (1..12).to_a.each do |mon|
+          (1..12).each do |mon|
             expect(@account.send("credit_balance_#{mon}")).to eq 2000
             expect(@other_account.send("debit_balance_#{mon}")).to eq 3000
           end
@@ -620,7 +620,7 @@ RSpec.describe '仕訳モデルに関するテスト', type: :model do
           expect(@account.debit_balance_1).to eq 1000
           expect(@other_account.credit_balance_1).to eq 4000
           # 自身科目の4月以降借方残高、相手科目の4月以降貸方残高
-          (4..12).to_a.each do |mon|
+          (4..12).each do |mon|
             expect(@account.send("debit_balance_#{mon}")).to eq 1000
             expect(@other_account.send("credit_balance_#{mon}")).to eq 4000
           end
@@ -636,7 +636,7 @@ RSpec.describe '仕訳モデルに関するテスト', type: :model do
           expect(@account.opening_balance_3).to eq 9500
           expect(@other_account.opening_balance_3).to eq 20500
           # 自身科目の4月以降期首残高、相手科目の4月以降期首残高
-          (4..12).to_a.each do |mon|
+          (4..12).each do |mon|
             expect(@account.send("opening_balance_#{mon}")).to eq 10500
             expect(@other_account.send("opening_balance_#{mon}")).to eq 19500
           end
@@ -655,7 +655,7 @@ RSpec.describe '仕訳モデルに関するテスト', type: :model do
           expect(Journal.all.length).to eq 1
         end
         it '勘定科目の残高が変わっていない' do
-          (1..12).to_a.each do |mon|
+          (1..12).each do |mon|
             expect(@account.send("debit_balance_#{mon}")).to eq 1000
             expect(@account.send("credit_balance_#{mon}")).to eq 2000
             expect(@account.send("opening_balance_#{mon}")).to eq 10000
@@ -674,7 +674,7 @@ RSpec.describe '仕訳モデルに関するテスト', type: :model do
         other_account = create(:account, user: @user, code: 101, name: 'test')
         hash = {}
         other_hash = {}
-        (1..12).to_a.each do |mon|
+        (1..12).each do |mon|
           hash["debit_balance_#{mon}"] = 1000
           hash["credit_balance_#{mon}"] = 2000
           hash["opening_balance_#{mon}"] = 10000
@@ -700,7 +700,7 @@ RSpec.describe '仕訳モデルに関するテスト', type: :model do
         end
         it '以下の残高は変わっていない' do
           # 自身科目の貸方残高、相手科目の借方残高
-          (1..12).to_a.each do |mon|
+          (1..12).each do |mon|
             expect(@account.send("credit_balance_#{mon}")).to eq 2000
             expect(@other_account.send("debit_balance_#{mon}")).to eq 3000
           end
@@ -713,7 +713,7 @@ RSpec.describe '仕訳モデルに関するテスト', type: :model do
           expect(@account.debit_balance_1).to eq 1000
           expect(@other_account.credit_balance_1).to eq 4000
           # 自身科目の4月以降借方残高、相手科目の4月以降貸方残高
-          (4..12).to_a.each do |mon|
+          (4..12).each do |mon|
             expect(@account.send("debit_balance_#{mon}")).to eq 1000
             expect(@other_account.send("credit_balance_#{mon}")).to eq 4000
           end
@@ -729,7 +729,7 @@ RSpec.describe '仕訳モデルに関するテスト', type: :model do
           expect(@account.opening_balance_3).to eq 9500
           expect(@other_account.opening_balance_3).to eq 20500
           # 自身科目の4月以降期首残高、相手科目の4月以降期首残高
-          (4..12).to_a.each do |mon|
+          (4..12).each do |mon|
             expect(@account.send("opening_balance_#{mon}")).to eq 10500
             expect(@other_account.send("opening_balance_#{mon}")).to eq 19500
           end
@@ -748,7 +748,7 @@ RSpec.describe '仕訳モデルに関するテスト', type: :model do
           expect(Journal.all.length).to eq 1
         end
         it '勘定科目の残高が変わっていない' do
-          (1..12).to_a.each do |mon|
+          (1..12).each do |mon|
             expect(@account.send("debit_balance_#{mon}")).to eq 1000
             expect(@account.send("credit_balance_#{mon}")).to eq 2000
             expect(@account.send("opening_balance_#{mon}")).to eq 10000
@@ -767,7 +767,7 @@ RSpec.describe '仕訳モデルに関するテスト', type: :model do
         other_account = create(:account, user: @user, code: 101, name: 'test')
         hash = {}
         other_hash = {}
-        (1..12).to_a.each do |mon|
+        (1..12).each do |mon|
           hash["debit_balance_#{mon}"] = 1000
           hash["credit_balance_#{mon}"] = 2000
           hash["opening_balance_#{mon}"] = 10000
@@ -784,12 +784,12 @@ RSpec.describe '仕訳モデルに関するテスト', type: :model do
       end
 
       it '借方科目の貸方残高は変わっていない' do
-        (1..12).to_a.each do |mon|
+        (1..12).each do |mon|
           expect(@account.send("credit_balance_#{mon}")).to eq 2000
         end
       end
       it '貸方科目の借方残高は変わっていない' do
-        (1..12).to_a.each do |mon|
+        (1..12).each do |mon|
           expect(@other_account.send("debit_balance_#{mon}")).to eq 3000
         end
       end
@@ -805,13 +805,13 @@ RSpec.describe '仕訳モデルに関するテスト', type: :model do
       end
       it '借方科目の削除仕訳月の借方残高、削除仕訳月より後の期首残高は変わっている' do
         expect(@account.debit_balance_2).to eq 500
-        (3..12).to_a.each do |mon|
+        (3..12).each do |mon|
           expect(@account.send("opening_balance_#{mon}")).to eq 9500
         end
       end
       it '貸方科目の削除仕訳月の貸方残高、削除仕訳月より後の期首残高は変わっている' do
         expect(@other_account.credit_balance_2).to eq 3500
-        (3..12).to_a.each do |mon|
+        (3..12).each do |mon|
           expect(@other_account.send("opening_balance_#{mon}")).to eq 20500
         end
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -256,7 +256,7 @@ RSpec.describe 'ユーザモデルに関するテスト', type: :model do
         user = create(:user, year: 2021)
         account = create(:account, user: user)
         other_account = create(:account, user: user, code: 101)
-        (1..12).to_a.each do |mon|
+        (1..12).each do |mon|
           account.update("opening_balance_#{mon}".to_sym => (mon - 1))
           other_account.update("opening_balance_#{mon}".to_sym => (mon - 1))
         end
@@ -274,7 +274,7 @@ RSpec.describe 'ユーザモデルに関するテスト', type: :model do
         other_profit_account = create(:account, user: user, code: 102, total_account: '収入')
         # 検証用に貸借の科目も一つ作成
         balance_account = create(:account, user: user)
-        (1..12).to_a.each do |mon|
+        (1..12).each do |mon|
           profit_account.update("credit_balance_#{mon}".to_sym => (mon * 3))
           profit_account.update("debit_balance_#{mon}".to_sym => mon)
           other_profit_account.update("credit_balance_#{mon}".to_sym => (mon * 3))


### PR DESCRIPTION
aからbの繰り返しをする際に、(a..b).to_a.eachと記述していたが、(a..b).eachと等価であるため削除